### PR TITLE
add pods using default cordova tools

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -26,8 +26,6 @@
     <repo>https://github.com/kitolog/cordova-plugin-zip-archive</repo>
     <issue>https://github.com/kitolog/cordova-plugin-zip-archive</issue>
 
-    <dependency id="cordova-plugin-cocoapod-support"/>
-
     <engines>
         <engine name="cordova-android" version=">=3.6.0"/><!-- Requires CordovaPlugin.preferences -->
         <engine name="cordova-ios" version=">=4.0.0"/>
@@ -65,7 +63,14 @@
         </config-file>
 
 <!--        <framework src="SSZipArchive" type="podspec" spec="~> 2.2.3" />-->
-        <pod name="SSZipArchive" git="https://github.com/kitolog/ZipArchive" branch="master" />
+        <podspec>
+            <config>
+                <source url="https://github.com/CocoaPods/Specs.git" />
+            </config>
+            <pods use-frameworks="true">
+                <pod name="SSZipArchive" git="https://github.com/kitolog/ZipArchive" branch="master" />
+            </pods>
+        </podspec>
 
         <header-file src="src/ios/ZipArchiveAdapter.h"/>
         <source-file src="src/ios/ZipArchiveAdapter.m"/>


### PR DESCRIPTION
import pods using new syntax https://cordova.apache.org/docs/en/latest/plugin_ref/spec.html#podspec-ios

in the current version, conflicts can occur while installing pods